### PR TITLE
Adds pretty printing option

### DIFF
--- a/jl.cabal
+++ b/jl.cabal
@@ -34,5 +34,5 @@ executable jl
   main-is:             Main.hs
   ghc-options:         -Wall -O2 -static
   build-depends:       base
-                     , jl, text, aeson, containers, bytestring, mtl, optparse-simple, vector
+                     , jl, text, aeson, aeson-pretty, containers, bytestring, mtl, optparse-simple, vector
   default-language:    Haskell2010


### PR DESCRIPTION
This change would include the option for pretty printing the JSON output via `Data-Aeson-Encode-Pretty.encodePretty`.

```
jl --pretty id <<< '{"foo":"bar","baz":[1,2,3,4]}'
{
    "foo": "bar",
    "baz": [
        1,
        2,
        3,
        4
    ]
}
```