### PR TITLE
Update for MonadFail in GHC 8.6

### DIFF
--- a/src/JL/Inferer.hs
+++ b/src/JL/Inferer.hs
@@ -117,10 +117,13 @@ check ctx expr =
 generateTypeVariable
   :: MonadState ([TypeVariable]) m
   => m TypeVariable
-generateTypeVariable = do
-  v:vs <- get
-  put vs
-  pure v
+generateTypeVariable =
+  get >>= \case
+    v:vs -> do
+      put vs
+      pure v
+    _ ->
+      error "Ran out of type variables"
 
 -- | Unify the list of constraints.
 unify


### PR DESCRIPTION
Use error instead of propagating failure upwards. The error will never happen in practice since the stream of type variables is infinite.

Fixes #16

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/chrisdone/jl/17)
<!-- Reviewable:end -->
